### PR TITLE
replace www.lichess.org with https://lichess.org

### DIFF
--- a/chessbot.py
+++ b/chessbot.py
@@ -112,15 +112,15 @@ def generateMessage(fen, certainty, side):
   vals['inverted_fen_w'] = "%s w %s -" % (inverted_fen, inverted_castle_status)
   vals['inverted_fen_b'] = "%s b %s -" % (inverted_fen, inverted_castle_status)
 
-  vals['lichess_analysis_w'] = 'http://www.lichess.org/analysis/%s_w_%s' % (fen, castle_status)
-  vals['lichess_analysis_b'] = 'http://www.lichess.org/analysis/%s_b_%s' % (fen, castle_status)
-  vals['lichess_editor_w'] = 'http://www.lichess.org/editor/%s_w_%s' % (fen, castle_status)
-  vals['lichess_editor_b'] = 'http://www.lichess.org/editor/%s_b_%s' % (fen, castle_status)
+  vals['lichess_analysis_w'] = 'https://lichess.org/analysis/%s_w_%s' % (fen, castle_status)
+  vals['lichess_analysis_b'] = 'https://lichess.org/analysis/%s_b_%s' % (fen, castle_status)
+  vals['lichess_editor_w'] = 'https://lichess.org/editor/%s_w_%s' % (fen, castle_status)
+  vals['lichess_editor_b'] = 'https://lichess.org/editor/%s_b_%s' % (fen, castle_status)
 
-  vals['inverted_lichess_analysis_w'] = 'http://www.lichess.org/analysis/%s_w_%s' % (inverted_fen, inverted_castle_status)
-  vals['inverted_lichess_analysis_b'] = 'http://www.lichess.org/analysis/%s_b_%s' % (inverted_fen, inverted_castle_status)
-  vals['inverted_lichess_editor_w'] = 'http://www.lichess.org/editor/%s_w_%s' % (inverted_fen, inverted_castle_status)
-  vals['inverted_lichess_editor_b'] = 'http://www.lichess.org/editor/%s_b_%s' % (inverted_fen, inverted_castle_status)
+  vals['inverted_lichess_analysis_w'] = 'https://lichess.org/analysis/%s_w_%s' % (inverted_fen, inverted_castle_status)
+  vals['inverted_lichess_analysis_b'] = 'https://lichess.org/analysis/%s_b_%s' % (inverted_fen, inverted_castle_status)
+  vals['inverted_lichess_editor_w'] = 'https://lichess.org/editor/%s_w_%s' % (inverted_fen, inverted_castle_status)
+  vals['inverted_lichess_editor_b'] = 'https://lichess.org/editor/%s_b_%s' % (inverted_fen, inverted_castle_status)
   
   return message_template.format(**vals)
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@ TensorFlow Chessbot - /u/ChessFenBot [◕ _ ◕]<sup>\* *I make FENs*</sup>
 ---
 
 **TL;DR**: 
-> Turn http://i.imgur.com/HnWYt8A.png → [1nkr4/1p3q1p/pP4pn/P1r5/3N1p2/2b2B1P/5PPB/2RQ1RK1](http://www.lichess.org/analysis/1nkr4/1p3q1p/pP4pn/P1r5/3N1p2/2b2B1P/5PPB/2RQ1RK1_w)
+> Turn http://i.imgur.com/HnWYt8A.png → [1nkr4/1p3q1p/pP4pn/P1r5/3N1p2/2b2B1P/5PPB/2RQ1RK1](https://lichess.org/analysis/1nkr4/1p3q1p/pP4pn/P1r5/3N1p2/2b2B1P/5PPB/2RQ1RK1_w)
 
 ![Prediction](readme_images/prediction.png)
 
@@ -68,7 +68,7 @@ Similarly, a URL can be tested by calling with a URL:
 
 [/u/ChessFenBot](https://www.reddit.com/user/ChessFenBot) will automatically reply to [reddit /r/chess](https://www.reddit.com/r/) new topic image posts that contain detectable online chessboard screenshots. A screenshot either ends in `.png`, `.jpg`, `.gif`, or is an `imgur` link. 
 
-It replies with a [lichess](http://www.lichess.org) analysis link for that layout and a predicted [FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation).
+It replies with a [lichess](https://lichess.org) analysis link for that layout and a predicted [FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation).
 
 ```py
 predictor = ChessboardPredictor()
@@ -95,11 +95,11 @@ ChessFenBot automatically replied to [this reddit post](https://www.reddit.com/r
 > 
 > FEN: [1nkr4/1p3q1p/pP4pn/P1r5/3N1p2/2b2B1P/5PPB/2RQ1RK1](http://www.fen-to-image.com/image/30/1nkr1111/1p111q1p/pP1111pn/P1r11111/111N1p11/11b11B1P/11111PPB/11RQ1RK1.png)
 > 
-> Here is a link to a [Lichess Analysis](http://www.lichess.org/analysis/1nkr4/1p3q1p/pP4pn/P1r5/3N1p2/2b2B1P/5PPB/2RQ1RK1_w) - White to play
+> Here is a link to a [Lichess Analysis](https://lichess.org/analysis/1nkr4/1p3q1p/pP4pn/P1r5/3N1p2/2b2B1P/5PPB/2RQ1RK1_w) - White to play
 > 
 > ---
 > 
-> <sup>Yes I am a machine learning bot | [`How I work`](https://github.com/Elucidation/tensorflow_chessbot 'Must go deeper') | Reply with a corrected FEN or [Editor link)](http://www.lichess.org/editor/r1b1r1k1/5pp1/p1pR1nNp/8/2B5/2q5/P1P1Q1PP/5R1K) to add to my next training dataset</sup>
+> <sup>Yes I am a machine learning bot | [`How I work`](https://github.com/Elucidation/tensorflow_chessbot 'Must go deeper') | Reply with a corrected FEN or [Editor link)](https://lichess.org/editor/r1b1r1k1/5pp1/p1pR1nNp/8/2B5/2q5/P1P1Q1PP/5R1K) to add to my next training dataset</sup>
 
 ## Workflow
 

--- a/tensorflow_generate_training_data.ipynb
+++ b/tensorflow_generate_training_data.ipynb
@@ -101,7 +101,7 @@
     "## Generating screenshots of the FEN\n",
     "This seemingly daunting task is actually not too bad thanks to the help of several others.  One way is to programmatically load a url and get a render is to use [`pythonwebkit2png`](https://github.com/adamn/python-webkit2png). \n",
     "\n",
-    "In our case we will use several websites eventually, but this notebook shows just [lichess](lichess.org). Lichess provides a RESTful protocol `www.lichess.org/editor/<FEN-STRING>` which loads a page with the board in the FEN configuration."
+    "In our case we will use several websites eventually, but this notebook shows just [lichess](https://lichess.org). Lichess provides a RESTful protocol `https://lichess.org/editor/<FEN-STRING>` which loads a page with the board in the FEN configuration."
    ]
   },
   {

--- a/tensorflow_learn.ipynb
+++ b/tensorflow_learn.ipynb
@@ -1019,7 +1019,7 @@
     {
      "data": {
       "text/markdown": [
-       "Prediction: [Lichess analysis](http://www.lichess.org/analysis/rnbq1rk1/ppp11pb1/111p11n1/11111111/111PPP11/1BP11Q11/PP111111/RNB11RK1)"
+       "Prediction: [Lichess analysis](https://lichess.org/analysis/rnbq1rk1/ppp11pb1/111p11n1/11111111/111PPP11/1BP11Q11/PP111111/RNB11RK1)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1066,7 +1066,7 @@
     "print \"FEN:\",fen\n",
     "\n",
     "# See our prediction as a chessboard\n",
-    "display(Markdown(\"Prediction: [Lichess analysis](http://www.lichess.org/analysis/%s)\" % fen))\n",
+    "display(Markdown(\"Prediction: [Lichess analysis](https://lichess.org/analysis/%s)\" % fen))\n",
     "display(Image(url='http://www.fen-to-image.com/image/%s' % fen))\n",
     "\n",
     "# See the original screenshot we took from reddit\n",
@@ -1127,7 +1127,7 @@
     "    \n",
     "    # Make prediction\n",
     "    fen = getPrediction(img)\n",
-    "    display(Markdown(\"Prediction: [Lichess analysis](http://www.lichess.org/analysis/%s)\" % fen))\n",
+    "    display(Markdown(\"Prediction: [Lichess analysis](https://lichess.org/analysis/%s)\" % fen))\n",
     "    display(Image(url='http://www.fen-to-image.com/image/%s' % fen))\n",
     "    print \"FEN: %s\" % fen    \n"
    ]
@@ -1170,7 +1170,7 @@
     {
      "data": {
       "text/markdown": [
-       "Prediction: [Lichess analysis](http://www.lichess.org/analysis/KQ111B11/P11bN1P1/11P111R1/b11P1111/111p1P11/11111111/pp111111/1kq1r111)"
+       "Prediction: [Lichess analysis](https://lichess.org/analysis/KQ111B11/P11bN1P1/11P111R1/b11P1111/111p1P11/11111111/pp111111/1kq1r111)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1239,7 +1239,7 @@
     {
      "data": {
       "text/markdown": [
-       "Prediction: [Lichess analysis](http://www.lichess.org/analysis/11111111/1111B111/bBK11Nr1/11111111/11b1B1B1/b11k1111/1b111b11/11111111)"
+       "Prediction: [Lichess analysis](https://lichess.org/analysis/11111111/1111B111/bBK11Nr1/11111111/11b1B1B1/b11k1111/1b111b11/11111111)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1306,7 +1306,7 @@
     {
      "data": {
       "text/markdown": [
-       "Prediction: [Lichess analysis](http://www.lichess.org/analysis/111111k1/11111rp1/1111111p/1pp1Pr11/p11pKPR1/1P1111R1/P1111P11/11111111)"
+       "Prediction: [Lichess analysis](https://lichess.org/analysis/111111k1/11111rp1/1111111p/1pp1Pr11/p11pKPR1/1P1111R1/P1111P11/11111111)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1375,7 +1375,7 @@
     {
      "data": {
       "text/markdown": [
-       "Prediction: [Lichess analysis](http://www.lichess.org/analysis/11kr111r/p1p11ppp/11pb1111/111N1q11/1111n1b1/1111BN11/PPP1QPPP/11KR111R)"
+       "Prediction: [Lichess analysis](https://lichess.org/analysis/11kr111r/p1p11ppp/11pb1111/111N1q11/1111n1b1/1111BN11/PPP1QPPP/11KR111R)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1442,7 +1442,7 @@
     {
      "data": {
       "text/markdown": [
-       "Prediction: [Lichess analysis](http://www.lichess.org/analysis/1Qr11B1r/pp111pp1/11p111p1/11pn11pB/111qp111/r111bB1p/pp11b111/1k11q1r1)"
+       "Prediction: [Lichess analysis](https://lichess.org/analysis/1Qr11B1r/pp111pp1/11p111p1/11pn11pB/111qp111/r111bB1p/pp11b111/1k11q1r1)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1502,7 +1502,7 @@
     {
      "data": {
       "text/markdown": [
-       "Prediction: [Lichess analysis](http://www.lichess.org/analysis/11111111/11111p11/11111R1P/11p11111/1p1p1111/11111111/111K1111/11111111)"
+       "Prediction: [Lichess analysis](https://lichess.org/analysis/11111111/11111p11/11111R1P/11p11111/1p1p1111/11111111/111K1111/11111111)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1562,7 +1562,7 @@
     {
      "data": {
       "text/markdown": [
-       "Prediction: [Lichess analysis](http://www.lichess.org/analysis/111r1rk1/ppp1q1pp/1nn1pb11/11111b11/11bP1111/11N1BN11/pP1QB1bP/111R1RK1)"
+       "Prediction: [Lichess analysis](https://lichess.org/analysis/111r1rk1/ppp1q1pp/1nn1pb11/11111b11/11bP1111/11N1BN11/pP1QB1bP/111R1RK1)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1622,7 +1622,7 @@
     {
      "data": {
       "text/markdown": [
-       "Prediction: [Lichess analysis](http://www.lichess.org/analysis/r1bqnr11/pp1ppkbp/1111N1p1/n111P111/11111111/11N1B111/PPP11PPP/R11QK11R)"
+       "Prediction: [Lichess analysis](https://lichess.org/analysis/r1bqnr11/pp1ppkbp/1111N1p1/n111P111/11111111/11N1B111/PPP11PPP/R11QK11R)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1682,7 +1682,7 @@
     {
      "data": {
       "text/markdown": [
-       "Prediction: [Lichess analysis](http://www.lichess.org/analysis/rnbqkbnr/pp1ppppp/11111111/11p11111/1111P111/11111111/PPPP1PPP/RNBQKBNR)"
+       "Prediction: [Lichess analysis](https://lichess.org/analysis/rnbqkbnr/pp1ppppp/11111111/11p11111/1111P111/11111111/PPPP1PPP/RNBQKBNR)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1742,7 +1742,7 @@
     {
      "data": {
       "text/markdown": [
-       "Prediction: [Lichess analysis](http://www.lichess.org/analysis/rnbqkbnr/pPpppppp/11111111/11P11111/11111111/111R1111/PP1PPPPP/RNBQKBNR)"
+       "Prediction: [Lichess analysis](https://lichess.org/analysis/rnbqkbnr/pPpppppp/11111111/11P11111/11111111/111R1111/PP1PPPPP/RNBQKBNR)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"


### PR DESCRIPTION
There's no www subdomain on lichess, and SSL is recommended.